### PR TITLE
Use dedicated entry point for `pkg` to be able to pick up assets, etc

### DIFF
--- a/packages/ibis-api/package.json
+++ b/packages/ibis-api/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
+  "bin": "start.js",
   "scripts": {
-    "start": "node dist/start.js",
+    "start": "node start.js",
     "test": "ava --tap",
     "build": "tsc --project tsconfig.json && tsc --project tsconfig.js.json",
     "pkg": "pkg dist/start.js --out-path dist",

--- a/packages/ibis-api/src/index.ts
+++ b/packages/ibis-api/src/index.ts
@@ -5,7 +5,7 @@ import { h2 } from "ibis-lib"
 export { port, hostname, apiHostname, default as config } from "./config"
 export { SearchResult, CategorizedSearchMap, CategorizedSearchResult } from "./db"
 
-export default () => {
+export const start = () => {
     h2(app)
         .then(async server => {
             await initialize()

--- a/packages/ibis-api/src/start.ts
+++ b/packages/ibis-api/src/start.ts
@@ -1,3 +1,0 @@
-import start from "./index"
-
-start()

--- a/packages/ibis-api/start.js
+++ b/packages/ibis-api/start.js
@@ -1,0 +1,3 @@
+const api = require("./dist/index")
+
+api.start()

--- a/packages/ibis-app/package.json
+++ b/packages/ibis-app/package.json
@@ -2,9 +2,10 @@
   "name": "ibis-app",
   "version": "1.0.0",
   "description": "",
-  "main": "dist/index.js",
+  "main": "start.js",
+  "bin": "start.js",
   "scripts": {
-    "start": "node dist/index.js",
+    "start": "node start.js",
     "test": "ava --tap",
     "build": "gulp && npm run build:browser",
     "build:browser": "rollup --config ./src/public/rollup.config.js",

--- a/packages/ibis-app/src/index.ts
+++ b/packages/ibis-app/src/index.ts
@@ -3,7 +3,7 @@ import { h2 } from "ibis-lib"
 
 import app from "./app"
 
-h2(app)
+export const start = () => h2(app)
         .then(server => {
                 console.log(`Listening on ${appHostname}`)
                 server.listen(port, hostname)

--- a/packages/ibis-app/start.js
+++ b/packages/ibis-app/start.js
@@ -1,0 +1,3 @@
+const app = require("./dist/index")
+
+app.start()


### PR DESCRIPTION
## summary

`pkg` likes being able to read `package.json` to be able to pick up assets, scripts, and the like. However, `npm ci` does a `chmod +x` on any entries in `bin`, which causes issues if the entry point is not build yet (not checked into source). This PR adds a dedicated entrypoint script for both the API and the app, so `npm ci` and `pkg` can work at the same time.